### PR TITLE
Upgrade to 1.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>bootstrap-select</artifactId>
-    <version>1.12.1-SNAPSHOT</version>
+    <version>1.12.2-SNAPSHOT</version>
     <name>bootstrap-select</name>
     <description>WebJar for bootstrap-select</description>
     <url>http://webjars.org</url>
@@ -49,7 +49,7 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>1.12.0</upstream.version>
+        <upstream.version>1.12.2</upstream.version>
         <upstream.url>https://github.com/silviomoreto/bootstrap-select/archive</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
         <requirejs>


### PR DESCRIPTION
I could use a release of 1.12.2 for something I am working on. There was a 1.12.1 release but it's probably safe to skip it. 